### PR TITLE
fix(session): Ensure session object is mutable

### DIFF
--- a/templates/index.js.ejs
+++ b/templates/index.js.ejs
@@ -15,7 +15,8 @@ export default {
             const jwt = cookie.split('__session=')[1].split(';')[0];
             try {
                 const { payload } = await jose.jwtVerify(jwt, JWT_SECRET);
-                request.session = payload;
+                // We create a shallow copy to make the session object mutable
+                request.session = { ...payload };
             } catch (e) {
                 // Invalid JWT, continue with empty session
                 console.error('JWT verification failed:', e.message);


### PR DESCRIPTION
The `jose.jwtVerify` function returns a frozen (immutable) payload object. The previous code assigned this object directly to `request.session`. Subsequent attempts to modify the session object in request handlers (e.g., to set `userId` on login) would fail silently because the object could not be changed.

This commit fixes the issue by creating a shallow copy of the JWT payload (`{ ...payload }`) before assigning it to `request.session`. This ensures that the session object is mutable, allowing handlers to correctly modify it and trigger the session-saving logic.